### PR TITLE
Clean up code

### DIFF
--- a/docs/build-summary.md
+++ b/docs/build-summary.md
@@ -1,6 +1,6 @@
 # Build summary recipe
 
-Creates a summary of current build information to preview what is currently deployed
+Creates a summary of current build information to preview what is currently deployed.
 
 ## Usage
 
@@ -11,30 +11,42 @@ require 'vendor/studio24/deployer-recipes/src/build-summary.php';
 ```
 
 ## Configuration
-Creates a file containing:
-* Current environment
-* The current build date & time
-* The currently deployed branch
-* The Commit ID
-* Who made the deployment
+No configuration is required.
 
 ## Tasks
 
-- `studio24:build-summary` – retrieves current deployment info and create a _build_summary.json file
+- `studio24:build-summary` – retrieves current deployment info and creates a `_build_summary.json` file in the web root
 
 ## Usage
 
-Run on any environment to create the file   
+Add task to your `deploy.php` script:
 
-```dep studio24:build-summary environment```  
+```
+task('deploy', [
+    ...
+    // Add before deploy:symlink
+    'studio24:build-summary',
+    
+    'deploy:symlink',
+    ...
+]);
+```
 
-eg:
-```dep studio24:build-summary staging```  
-  
-view the file by adding the name to the URI  
-```https://website_url/_build_summary.json```
+This creates a file containing:
+* Current environment
+* The current build date & time
+* The currently deployed branch
+* The commit ID
+* Who made the deployment
 
+Example:
 
-
-
-
+```json
+{
+  "environment": "staging",
+  "buildDateTime": "20210303_163358",
+  "gitBranch": "hotfix\/101-update-team",
+  "commitId": "01543dac170435769afa6ab90ef838d0c3001ac5",
+  "deployedBy": "Alan Isaacson (alan@studio24.net)"
+}
+```

--- a/src/build-summary.php
+++ b/src/build-summary.php
@@ -2,23 +2,19 @@
 
 namespace Deployer;
 
-desc('Creates a _build_summary.json file on the webserver');
-task('Studio24:build-summary',function() {
-cd('{{release_path}}/'.get('webroot'));
-$build_data = [
-'environment' => get('stage'),
-'buildDateTime' => date('Ymd_His'),
-'gitBranch' => get('branch'),
-'commitId' => run('git rev-parse HEAD'),
-'deployedBy' => runLocally('git config user.name') . ' (' . runLocally('git config user.email') . ')',
-];
+desc('Creates a _build_summary.json file in the webserver doc root');
+task('Studio24:build-summary', function () {
+    cd('{{release_path}}/' . get('webroot'));
+    $build_data = [
+        'environment' => get('stage'),
+        'buildDateTime' => date('Ymd_His'),
+        'gitBranch' => get('branch'),
+        'commitId' => run('git rev-parse HEAD'),
+        'deployedBy' => runLocally('git config user.name') . ' (' . runLocally('git config user.email') . ')',
+    ];
 
-    run('echo \''.json_encode($build_data).'\' > _build_summary.json');
+    run("echo '" . json_encode($build_data, JSON_PRETTY_PRINT) . "' > _build_summary.json");
 
-    $url = get('url');
-    $url = rtrim($url, '/') . '/';
-
-
-    writeln ('Build summary located at ' . $url . '_build_summary.json');
-
+    $url = rtrim(get('url'), '/') . '/';
+    writeln('Build summary saved to: ' . $url . '_build_summary.json');
 });


### PR DESCRIPTION
hi - some suggested code changes in these commits. Happy to talk these through.

**studio24:build-summary**
* Can I suggest we use name_name format in JSON variables and group these up a bit more logically, e.g. environment, deploy_datetime, deployed_by, git_branch, git_commit
* Can I suggest we use the ISO 8601 date for simplicity (it's also easier tro convert back into a datetime), `date('c')` - though may be more reliable to use DateTime..
```
$now = new DateTime();
echo $now->format('c');
```

* Would it be useful to add Git repo link for this commit? We have privacy on repo URLs so this should be safe. E.g. something like this:

```
$pathinfo = pathinfo(get('repository'));
$repoUrl = 'https://' . $pathinfo['basename'] . '/' . pathinfo['filename'] . '/commit/' .  $build_data['git_commit'];
```

Bitbucket URL format is: commits
Instead of: commit

You can use switch to detect GitHub/Bitbucket and output the right URL format.

Simon