### PR TITLE
Parse legacy date format for showing last build info

### DIFF
--- a/docs/common-issues.md
+++ b/docs/common-issues.md
@@ -29,17 +29,9 @@ composer global remove deployer/deployer
 sudo rm /usr/local/bin/dep
 ```
 
-## Legacy date formats in Build summaries
-
-We have encountered issues in some legacy projects where the Date/time format in the build summary is
-```
-20240415_094357
-```
-The file [tasks/show-summary.php](tasks/show-summary.md) now checks for both date formats to return the build summary.
-
 ## Fixing permission issues for deploy:writeable
-When updating projects to use `release 2.0` of Deployer Recipes we have encountered issues wih the ```deploy:writeable``` and ```deploy:shared``` tasks failing to re-assign correct permissions.
-For example 
+When updating projects to use v2 of Deployer Recipes we have encountered issues wih the ```deploy:writeable``` and ```deploy:shared``` tasks failing to re-assign correct permissions.
+For example: 
 ```
 task deploy:writable
 [staging]  error  in writable.php on line 121:
@@ -50,25 +42,29 @@ ERROR: Task deploy:writable failed!
 ```
 
 To fix this on a **staging** site we followed the below process:
-* Renamed the shared dir with ```mv /data/var/www/HOSTNAME/staging/shared /data/var/www/HOSTNAME/staging/shared-original```
-* Re-deploy ```./vendor/bin/dep deploy:prepare staging```
-* This will recreate the required shared dirs, with the correct permissions
-* This will lock the deployment, unlock with ```./vendor/bin/dep deploy:unlock staging```
-* Copy any shared files required from the ```shared-original``` to the ```shared``` dir
+* Renamed the shared dir with `mv /data/var/www/HOSTNAME/staging/shared /data/var/www/HOSTNAME/staging/shared-original`
+* Re-run the `shared` and `writable` deployment tasks to re-create these shared folders with the correct permissions:
+```
+./vendor/bin/dep deploy:shared staging
+./vendor/bin/dep deploy:writable staging
+```
+* Copy any required shared files from the `shared-original` to the `shared` dir
 
 ### Check permissions
-To check the permissions on the dir use ```getfacl /data/var/www/HOSTNAME/staging/shared/storage/app/```
+To check the permissions on the dir use `getfacl shared/storage/app/`
 
-If a sub-directory has permission issues and needs to be the same as its parent, eg.
-Writable
+If a sub-directory has permission issues and needs to be the same as its parent, e.g.
+
 ```
+# Writable
 /data/var/www/HOSTNAME/staging/shared/uploads
-```
-Non-writable
-```
+
+# Non-writable
 /data/var/www/HOSTNAME/staging/shared/uploads/2024
 ```
-Then you can
+
+Then you can run:
+
 ```
 cd /data/var/www/HOSTNAME/staging/shared/uploads/2024
 setfacl -m m::rwx .

--- a/docs/common-issues.md
+++ b/docs/common-issues.md
@@ -28,3 +28,49 @@ To remove any global installation run:
 composer global remove deployer/deployer
 sudo rm /usr/local/bin/dep
 ```
+
+## Legacy date formats in Build summaries
+
+We have encountered issues in some legacy projects where the Date/time format in the build summary is
+```
+20240415_094357
+```
+The file [tasks/show-summary.php](tasks/show-summary.md) now checks for both date formats to return the build summary.
+
+## Fixing permission issues for deploy:writeable
+When updating projects to use `release 2.0` of Deployer Recipes we have encountered issues wih the ```deploy:writeable``` and ```deploy:shared``` tasks failing to re-assign correct permissions.
+For example 
+```
+task deploy:writable
+[staging]  error  in writable.php on line 121:
+[staging] run cd /data/var/www/HOSTNAME/staging/releases/3 && (setfacl -L  -m u:"apache":rwX -m u:deploy:rwX storage/app/public)
+[staging] err setfacl: storage/app/: Operation not permitted
+[staging] exit code 1 (General error)
+ERROR: Task deploy:writable failed!
+```
+
+To fix this on a **staging** site we followed the below process:
+* Renamed the shared dir with ```mv /data/var/www/HOSTNAME/staging/shared /data/var/www/HOSTNAME/staging/shared-original```
+* Re-deploy ```./vendor/bin/dep deploy:prepare staging```
+* This will recreate the required shared dirs, with the correct permissions
+* This will lock the deployment, unlock with ```./vendor/bin/dep deploy:unlock staging```
+* Copy any shared files required from the ```shared-original``` to the ```shared``` dir
+
+### Check permissions
+To check the permissions on the dir use ```getfacl /data/var/www/HOSTNAME/staging/shared/storage/app/```
+
+If a sub-directory has permission issues and needs to be the same as its parent, eg.
+Writable
+```
+/data/var/www/HOSTNAME/staging/shared/uploads
+```
+Non-writable
+```
+/data/var/www/HOSTNAME/staging/shared/uploads/2024
+```
+Then you can
+```
+cd /data/var/www/HOSTNAME/staging/shared/uploads/2024
+setfacl -m m::rwx .
+```
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -91,6 +91,8 @@ Many recipes contain predefined settings for `shared_files`, `shared_dirs`, `wri
 
 You can view these settings in the source code for the recipe.
 
+Please note we have some common settings in [recipe/common.php](../recipe/common.php) (e.g. http_user, remote_user). 
+
 To add a setting to your `deploy.php` file, you can use the [add()](https://deployer.org/docs/7.x/api#add) function. This will add to the predefined settings.
 
 To completely replace the settings in your `deploy.php` file, you can use the [set()](https://deployer.org/docs/7.x/api#set) function. This will replace the predefined settings.

--- a/docs/tasks/check-disk-space.md
+++ b/docs/tasks/check-disk-space.md
@@ -10,6 +10,8 @@ require 'vendor/studio24/deployer-recipes/tasks/check-disk-space.php';
 ```
 
 ## Configuration
+
+### disk_space_filesystem
 If you set the filesystem mount this check can review disk capacity and warn if it is too low.
 
 ```
@@ -19,6 +21,14 @@ set('disk_space_filesystem', '/data');
 # Mythic Beasts
 set('disk_space_filesystem', '/');
 ```
+
+### disk_space_threshold
+
+Set the disk space available (%) threshold to issue a disk space warning, by default this is 80.
+
+### disk_space_max
+
+Set the disk space available (%) threshold to halt deployment due to not enough server space, by default this is 97.
 
 ## Tasks
 

--- a/tasks/check-disk-space.php
+++ b/tasks/check-disk-space.php
@@ -15,6 +15,7 @@ desc('Check remote server disk usage');
 task('check:disk-space', function () {
     $filesystem = get('disk_space_filesystem', '');
     $threshold = (int) get('disk_space_threshold', 80);
+    $max = (int) get('disk_space_max', 97);
 
     if (!empty($filesystem)) {
         // Run for a specific filesystem volume
@@ -27,8 +28,10 @@ task('check:disk-space', function () {
         // One filesystem volume returned
         if (count($m[1]) === 1) {
             $used = $m[1][0];
-            if ($used > $threshold) {
-                writeln(sprintf("<error>Server disk space is almost full: %d%% used</error>", $used));
+            if ($used >= $max) {
+                throw new \Exception(sprintf('Server disk space is too full to deploy to (%d%% used)', $used));
+            } elseif ($used >= $threshold) {
+                writeln(sprintf("<warning>Server disk space is almost full: %d%% used</warning>", $used));
             } else {
                 writeln(sprintf("<info>Server disk space is OK: %d%% used</info>", $used));
             }

--- a/tasks/show-summary.php
+++ b/tasks/show-summary.php
@@ -71,7 +71,12 @@ task('show', function () {
     }
 
     // Output last build info
-    $date = new \DateTimeImmutable($buildData['deploy_datetime']);
+    try {
+        $date = new \DateTimeImmutable($buildData['deploy_datetime']);
+    } catch (\Exception $e) {
+        // Try old legacy format "20240415_094357"
+        $date = \DateTimeImmutable::createFromFormat('Ymd_His', $buildData['deploy_datetime']);
+    }
     $summary = sprintf(
         '<options=bold>Last build:</> <info>%s</> deployed <info>%s</> branch to <info>%s</> environment on <info>%s</>',
         $buildData['deployed_by'],


### PR DESCRIPTION
Fix to display last build info if using legacy date format e.g. "20240415_094357" 