### PR TITLE
Download WP core

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -53,6 +53,8 @@ For deploying WordPress websites.
 cp vendor/studio24/deployer-recipes/examples/wordpress.php ./deploy.php
 ```
 
+See [WordPress recipe](recipes/wordpress.md) docs.
+
 [Source](../recipe/wordpress.php)
 
 ### Laravel:

--- a/docs/recipes/wordpress.md
+++ b/docs/recipes/wordpress.md
@@ -1,0 +1,62 @@
+# WordPress
+
+Deploy a WordPress site
+
+## Recipe
+
+```
+require 'vendor/studio24/deployer-recipes/recipe/wordpress.php';
+```
+
+## Requirements
+WP-CLI must be available on the remote server.
+
+## Configuration
+This recipe downloads WordPress on deployment, by default to the folder `web/wordpress/`. You can change this via: 
+
+```php
+// WordPress core folder
+set('wordpress_core_folder', 'web/wordpress/');
+```
+
+## WP CLI
+If you need to call any [WP CLI](https://wp-cli.org/) commands this recipe includes the `wp()` function to allow you to do this.
+
+Usage:
+
+```php
+wp('command');
+```
+
+E.g. to run `wp core version`
+
+```php
+wp('core version');
+```
+
+This automatically sets the current environment using the `stage` variable. You can pass this manually as the second param:
+
+```php
+wp('core version', 'staging');
+```
+
+## Run Composer
+
+If you need to run Composer in the root folder add `deploy:vendors` to the deploy task in your `deploy.php` file: 
+
+```php
+task('deploy', [
+    'deploy:prepare',
+    'deploy:vendors',
+    'deploy:publish',
+]);
+```
+
+To run Composer in a sub-folder (which isn't recommended) 
+
+```php
+// Custom (non-root) composer installs
+set('composer_paths', [
+    'web/wp-content/plugins/s24-wp-image-optimiser'
+]);
+```

--- a/recipe/wordpress.php
+++ b/recipe/wordpress.php
@@ -2,7 +2,7 @@
 
 namespace Deployer;
 
-require_once 'recipe/wordpress.php';
+require_once 'recipe/common.php';
 require_once __DIR__ . '/common.php';
 
 // Shared files that need to persist between deployments
@@ -36,3 +36,36 @@ set('sync', [
         'shared/web/wp-content/uploads/' => 'web/wp-content/uploads'
     ],
 ]);
+
+// WordPress core folder
+set('wordpress_core_folder', 'web/wordpress/');
+
+// Download WordPress Core files
+task('deploy:download_wordpress', function() {
+    $path = "{{release_path}}/{{wordpress_core_folder}}";
+
+    // @see https://developer.wordpress.org/cli/commands/core/download/
+    wp('core download --skip-content --path=' . $path);
+
+    writeln('Downloaded WordPress version:');
+    wp('core version');
+});
+after('deploy:update_code', 'deploy:download_wordpress');
+
+/**
+ * Run WP CLI
+ *
+ * @param string $command wp command, e.g. core download
+ * @param ?string $stage environment, e.g. production. Defaults to the current stage name
+ * @return void
+ * @throws Exception\Exception
+ * @throws Exception\RunException
+ * @throws Exception\TimeoutException
+ */
+function wp(string $command, ?string $stage = null)
+{
+    if (null === $stage) {
+        $stage = get('stage', 'production');
+    }
+    run(sprintf('WP_ENV=%s wp %s', $stage, $command), real_time_output: true);
+}


### PR DESCRIPTION
Added to wordpress recipe:

- Download WordPress core (without the default themes and plugins).
- Add wp() function if you want to run other WP CLI commands.
- Add docs on how to use it, including how to run composer install in project root folder (the existing WP projects simply run composer install which is not optimised for production, deployer has a deploy:vendors task for this. 

## Testing

Require recipe:

```
require 'vendor/studio24/deployer-recipes/recipe/wordpress.php';
```

Set wordpress folder if different to web/wordpress/:

```
// WordPress core folder
set('wordpress_core_folder', 'path/to/wordpress/');
```

If you need to run composer in root add:

```
task('deploy', [
    'deploy:prepare',
    'deploy:vendors',
    'deploy:publish',
]);
```