### PR TITLE
Added composer Wordpress install

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,8 @@ This package contains [Deployer](https://deployer.org/) recipes used to help dep
 
 ## Recipes
 
-* [WordPress](recipes/wordpress.md)
+* [WordPress CLI installation](recipes/wordpress.md)
+* [WordPress Composer installation](recipes/wordpress-composer.md)
 * [Static site](recipes/static.md) - 
 * [Slack](recipes/slack.md) - send a notification to Slack when a deployment is complete
 

--- a/docs/recipes/wordpress.md
+++ b/docs/recipes/wordpress.md
@@ -44,8 +44,13 @@ This recipe requires [WP CLI](https://wp-cli.org/) to exist on the remote server
 
 You can copy an example deployment file:
 
+For WordPress sites using the CLI to install use
 ```
 cp vendor/studio24/deployer-recipes/examples/wordpress.php ./deploy.php
+```
+For WordPress sites using Composer to install use 
+```
+cp vendor/studio24/deployer-recipes/examples/wordpress-composer.php ./deploy.php
 ```
 
 ### Loading environment variables in wp-config

--- a/examples/wordpress-composer.php
+++ b/examples/wordpress-composer.php
@@ -1,0 +1,56 @@
+<?php
+namespace Deployer;
+
+/**
+ * 1. Deployer recipes we are using for this website
+ */
+require_once 'vendor/studio24/deployer-recipes/recipe/wordpress-composer.php';
+require 'contrib/php-fpm.php';
+
+/**
+ * 2. Deployment configuration variables
+ */
+
+// Project name
+set('application', 'My Application Name');
+
+// Git repo
+set('repository', 'git@github.com:studio24/xxx.git');
+
+// Filesystem volume we're deploying to
+set('disk_space_filesystem', '/');
+
+
+/**
+ * 3. Hosts
+ */
+
+host('production')
+    ->set('hostname', '1.2.3.4')
+    ->set('http_user', 'production')
+    ->set('deploy_path', '/var/www/vhosts/DOMAIN.co.uk/production')
+    ->set('log_files', [
+        '/var/log/apache2/DOMAIN.co.uk.access.log',
+        '/var/log/apache2/DOMAIN.co.uk.error.log',
+    ])
+    ->set('url', 'https://www.DOMAIN.co.uk');
+
+host('staging')
+    ->set('hostname', '1.2.3.4')
+    ->set('http_user', 'staging')
+    ->set('deploy_path', '/var/www/vhosts/DOMAIN.co.uk/staging')
+    ->set('log_files', [
+        '/var/log/apache2/staging.DOMAIN.co.uk.access.log',
+        '/var/log/apache2/staging.DOMAIN.co.uk.error.log',
+    ])
+    ->set('url', 'https://DOMAIN.studio24.dev');
+
+
+/**
+ * 4. Deployment tasks
+ *
+ * Any custom deployment tasks to run
+ */
+
+// PHP-FPM reload
+after('deploy', 'php-fpm:reload');

--- a/recipe/wordpress-composer.php
+++ b/recipe/wordpress-composer.php
@@ -41,16 +41,6 @@ set('sync', [
     ],
 ]);
 
-// Optionally install Composer vendors if composer.json exists in project root
-task('deploy:vendors_if_exists', function() {
-    if (test('[ -f {{release_path}}/composer.json ]')) {
-        writeln('Install vendors, composer.json found');
-        invoke('deploy:vendors');
-    } else {
-        writeln('Skipping, no composer.json found');
-    }
-});
-
 /**
  * Run WP CLI
  *
@@ -74,6 +64,6 @@ function wp(string $command, ?string $stage = null)
 desc('Deploys your project');
 task('deploy', [
     'deploy:prepare',
-    'deploy:vendors_if_exists',
+    'deploy:vendors',
     'deploy:publish',
 ]);

--- a/recipe/wordpress-composer.php
+++ b/recipe/wordpress-composer.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Deployer;
+
+require_once 'recipe/common.php';
+require_once __DIR__ . '/common.php';
+
+// Path to WordPress core
+set('wordpress_path', 'web/wordpress');
+
+// Shared files that need to persist between deployments
+set('shared_files', [
+    '.env'
+]);
+
+// Shared directories that need to persist between deployments
+set('shared_dirs', [
+    '.well-known',
+    'web/content/uploads',
+    'web/content/cache',
+]);
+
+// Writable directories
+set('writable_dirs', [
+    'web/content/uploads',
+    'web/content/cache',
+    '{{wordpress_path}}',
+]);
+
+// Deployment and HTTP users
+set('remote_user', 'deploy');
+set('http_user', 'apache');
+
+// Web root
+set('webroot', 'web');
+
+// Array of remote => local file locations to sync to your local dev environment
+set('sync', [
+    'images' => [
+        'shared/web/content/uploads/' => 'web/content/uploads'
+    ],
+]);
+
+// Optionally install Composer vendors if composer.json exists in project root
+task('deploy:vendors_if_exists', function() {
+    if (test('[ -f {{release_path}}/composer.json ]')) {
+        writeln('Install vendors, composer.json found');
+        invoke('deploy:vendors');
+    } else {
+        writeln('Skipping, no composer.json found');
+    }
+});
+
+/**
+ * Run WP CLI
+ *
+ * @param string $command wp command, e.g. core download
+ * @param ?string $stage environment, e.g. production. Defaults to the current stage name
+ * @return void
+ * @throws Exception\Exception
+ * @throws Exception\RunException
+ * @throws Exception\TimeoutException
+ */
+function wp(string $command, ?string $stage = null)
+{
+    if (null === $stage) {
+        $stage = get('stage', 'production');
+    }
+    run(sprintf('WP_ENV=%s wp %s', $stage, $command), real_time_output: true);
+}
+
+
+// Deployment tasks
+desc('Deploys your project');
+task('deploy', [
+    'deploy:prepare',
+    'deploy:vendors_if_exists',
+    'deploy:publish',
+]);


### PR DESCRIPTION
I have updated the docs to include a Composer installation for Wordpress as used on CASP. 

I think the docs may need adjusting or possibly split out to a Wordpress (CLI) and Wordpress (Composer) doc, happy to do so after feedback. 