### PR TITLE
Add ability to patch WordPress remotely via Deployer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
   ],
   "require": {
     "php": ">=8.0",
+    "ext-curl": "*",
     "deployer/deployer": "^7.3"
   },
   "require-dev": {

--- a/docs/recipes/wordpress.md
+++ b/docs/recipes/wordpress.md
@@ -151,8 +151,8 @@ dependencies into the root composer file.
 You can run minor updates (normally used for security patches) via Deployer:
 
 ```bash
-dep wp wordpress:patch staging
-dep wp wordpress:patch production
+dep wordpress:patch staging
+dep wordpress:patch production
 ```
 
 This:

--- a/docs/recipes/wordpress.md
+++ b/docs/recipes/wordpress.md
@@ -146,6 +146,22 @@ You can check this by running `dep tree deploy` which will show you the tasks to
 It is not recommended to have more than one composer.json file in a project. If you do have one, you should move the 
 dependencies into the root composer file.
 
+## Patch WordPress
+
+You can run minor updates (normally used for security patches) via Deployer:
+
+```bash
+dep wp wordpress:patch staging
+dep wp wordpress:patch production
+```
+
+This:
+- Updates to the latest minor version
+- Tests the homepage returns a 200 HTTP status code
+- If it fails, it rolls back to the previous version installed
+
+This process does not commit code or update your composer.lock file in version control. It is intended to roll out urgent security patches quickly.
+
 ## WP CLI
 If you need to call any [WP CLI](https://wp-cli.org/) commands this recipe includes the `wp()` function to allow you to do this.
 

--- a/recipe/wordpress-composer.php
+++ b/recipe/wordpress-composer.php
@@ -59,6 +59,12 @@ function wp(string $command, ?string $stage = null)
     run(sprintf('WP_ENV=%s wp %s', $stage, $command), real_time_output: true);
 }
 
+// Update security patches
+desc('Update security patches for WordPress via Composer');
+task('wordpress:patch', function() {
+    patchWordPress('composer');
+});
+
 
 // Deployment tasks
 desc('Deploys your project');

--- a/recipe/wordpress.php
+++ b/recipe/wordpress.php
@@ -89,6 +89,12 @@ function wp(string $command, ?string $stage = null)
     run(sprintf('WP_ENV=%s wp %s', $stage, $command), real_time_output: true);
 }
 
+// Update security patches
+desc('Update security patches for WordPress via WP CLI');
+task('wordpress:patch', function() {
+    patchWordPress('wpcli');
+});
+
 
 // Deployment tasks
 desc('Deploys your project');

--- a/tasks/patch-wordpress.php
+++ b/tasks/patch-wordpress.php
@@ -42,7 +42,7 @@ function patchWordPress(string $type = 'wpcli')
         warning('Cannot test website URL, url variable not set');
     }
     $handle = curl_init($url);
-    curl_setopt($handle,  CURLOPT_RETURNTRANSFER, TRUE);
+    curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
     curl_exec($handle);
     $httpCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
     if ($httpCode != 200) {
@@ -75,4 +75,3 @@ function patchWordPress(string $type = 'wpcli')
 //task('wordpress:patch', function() {
 //    patchWordPress('composer');
 //});
-

--- a/tasks/patch-wordpress.php
+++ b/tasks/patch-wordpress.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Deployer;
+
+/**
+ * Patch WordPress
+ *
+ * This is designed to help run minor updates to WordPress via Deployer
+ *
+ * It run updates to the latest minor/patch version, tests the homepage returns HTTP 200, and if it fails rolls back
+ *
+ * @param string $type
+ * @return void
+ * @throws Exception\Exception
+ * @throws Exception\RunException
+ * @throws Exception\TimeoutException
+ */
+function patchWordPress(string $type = 'wpcli')
+{
+    // Check current version
+    $oldVersion = run('wp version');
+
+    // Run updates
+    switch ($type) {
+        case 'wpcli':
+            run('wp update --minor', real_time_output: true);
+            break;
+        case 'composer':
+            run('composer update johnpbloch/wordpress-core --patch-only', real_time_output: true);
+            break;
+        default:
+            error('Type must be one of: wpcli, composer');
+            return;
+    }
+
+    $newVersion = run('wp version');
+    info(sprintf('Updated WordPress from %s to %s', $oldVersion, $newVersion));
+
+    // Test homepage
+    $url = get('url', null);
+    if ($url === null) {
+        warning('Cannot test website URL, url variable not set');
+    }
+    $handle = curl_init($url);
+    curl_setopt($handle,  CURLOPT_RETURNTRANSFER, TRUE);
+    curl_exec($handle);
+    $httpCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
+    if ($httpCode != 200) {
+        warning(sprintf('Website URL %s does not work and returns HTTP status code %d', $url, $httpCode));
+
+        // Rollback if homepage fails 200 HTTP status test
+        switch ($type) {
+            case 'wpcli':
+                run(sprintf('wp update --version=%s', $oldVersion), real_time_output: true);
+                break;
+            case 'composer':
+                run(sprintf('composer update --with johnpbloch/wordpress-core:%s', $oldVersion), real_time_output: true);
+                break;
+        }
+        info(sprintf('Rolled back WordPress to %s', $oldVersion));
+    }
+}
+
+
+/**
+ * Usage: use this in the WordPress recipe files
+ */
+
+//desc('Update security patches for WordPress via WP CLI');
+//task('wordpress:patch', function() {
+//    patchWordPress('wpcli');
+//});
+//
+//desc('Update security patches for WordPress via Composer');
+//task('wordpress:patch', function() {
+//    patchWordPress('composer');
+//});
+

--- a/tasks/patch-wordpress.php
+++ b/tasks/patch-wordpress.php
@@ -40,25 +40,28 @@ function patchWordPress(string $type = 'wpcli')
     $url = get('url', null);
     if ($url === null) {
         warning('Cannot test website URL, url variable not set');
+        return;
     }
     $handle = curl_init($url);
     curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
     curl_exec($handle);
     $httpCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
-    if ($httpCode != 200) {
-        warning(sprintf('Website URL %s does not work and returns HTTP status code %d', $url, $httpCode));
-
-        // Rollback if homepage fails 200 HTTP status test
-        switch ($type) {
-            case 'wpcli':
-                run(sprintf('wp update --version=%s', $oldVersion), real_time_output: true);
-                break;
-            case 'composer':
-                run(sprintf('composer update --with johnpbloch/wordpress-core:%s', $oldVersion), real_time_output: true);
-                break;
-        }
-        info(sprintf('Rolled back WordPress to %s', $oldVersion));
+    if ($httpCode == 200) {
+        info('All OK!');
+        return;
     }
+
+    // Rollback if homepage fails 200 HTTP status test
+    warning(sprintf('Website URL %s does not work and returns HTTP status code %d', $url, $httpCode));
+    switch ($type) {
+        case 'wpcli':
+            run(sprintf('wp update --version=%s', $oldVersion), real_time_output: true);
+            break;
+        case 'composer':
+            run(sprintf('composer update --with johnpbloch/wordpress-core:%s', $oldVersion), real_time_output: true);
+            break;
+    }
+    info(sprintf('Rolled back WordPress to %s', $oldVersion));
 }
 
 


### PR DESCRIPTION
This adds a wordpress:patch task to Deployer for WP CLI and Composer, which:

- Runs WP minor updates (via WP CLI or Composer)
- Tests the homepage
- If it fails, rolls back

Please note this assumes WP Core files are writable by the deploy user, which may not work in all cases.

This may help us speed up security updates. 